### PR TITLE
Fix for Rails >= 4

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 RedmineApp::Application.routes.draw do
-  match '*path', :to => 'cors#preflight', via: [:options]
+   match '*path', :to => 'cors#preflight', :via => [:get,:post], :constraints => {:method => 'OPTIONS'}
 end


### PR DESCRIPTION
This makes the CORS plugin work with RoR 4 and above. Tested and works with my Redmine installation.